### PR TITLE
feat: Configure project for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FSilkePilon%2FGithub-Trending-API)
+
 <p align="center"><img src="docs/trending.png" width="500"></p>
 
 <p align="center">

--- a/app/main.py
+++ b/app/main.py
@@ -25,17 +25,17 @@ from app.scraping import scraping_repositories
 app = fastapi.FastAPI()
 
 
-DOMAIN_NAME = "https://gh-trending-api.herokuapp.com"
+# DOMAIN_NAME = "https://gh-trending-api.herokuapp.com"
 
 
 @app.get("/")
 def help_routes() -> Dict[str, str]:
     """ API endpoints and documentation. """
     return {
-        "repositories": f"{DOMAIN_NAME}/repositories",
-        "developers": f"{DOMAIN_NAME}/developers",
-        "docs": f"{DOMAIN_NAME}/docs",
-        "redoc": f"{DOMAIN_NAME}/redoc",
+        "repositories": "/repositories",
+        "developers": "/developers",
+        "docs": "/docs",
+        "redoc": "/redoc",
     }
 
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "app/main.py",
+      "use": "@vercel/python",
+      "config": {
+        "runtime": "python3.9",
+        "pipInstall": true,
+        "requirementsFile": "requirements-prod.txt"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "app/main.py"
+    }
+  ]
+}


### PR DESCRIPTION
This commit introduces the necessary changes to allow deploying the Github-Trending-API to Vercel.

Changes include:
- Added `vercel.json` to define the build and deployment configuration for Vercel, specifying Python 3.9 and the FastAPI application entry point.
- Modified `app/main.py` to remove the hardcoded `DOMAIN_NAME` in the `help_routes` function, allowing Vercel to manage the domain and ensuring correct link generation.
- Updated `README.md` to include a "Deploy with Vercel" button, making it easy for you to deploy your own instance of the API.