### PR TITLE
feat: Configure project for Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,6 @@
       "use": "@vercel/python",
       "config": {
         "runtime": "python3.9",
-        "pipInstall": true,
         "requirementsFile": "requirements-prod.txt"
       }
     }


### PR DESCRIPTION
This commit introduces the necessary changes to allow deploying the
Github-Trending-API to Vercel.

Changes include:
- Added `vercel.json` to define the build and deployment configuration
  for Vercel, specifying Python 3.9 and the FastAPI application entry point.
- Modified `app/main.py` to remove the hardcoded `DOMAIN_NAME` in the
  `help_routes` function, allowing Vercel to manage the domain and
  ensuring correct link generation.
- Updated `README.md` to include a "Deploy with Vercel" button,
  making it easy for you to deploy your own instance of the API.